### PR TITLE
Fix image naming issue and update README for Docker instructions

### DIFF
--- a/docker-compose-postgres.yml
+++ b/docker-compose-postgres.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/lfpoulin/jpjr:latest
+    image: ghcr.io/lfpoulain/jpjr:latest
     container_name: jpjr_app
     env_file:
       - .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   app:
-    image: ghcr.io/lfpoulin/jpjr:latest
+    image: ghcr.io/lfpoulain/jpjr:latest
     container_name: jpjr_app
     env_file:
       - .env


### PR DESCRIPTION
Cette pull request corrige une erreur de ma part concernant le nom des images Docker (poulin au lieu de poulain).
J’en ai profité pour mettre à jour le fichier README.md de donner les instructions pour l'utilisation de docker.
Les tests ont été relancés après correction et ne révèlent pas d’autres anomalies à ce stade.