### PR TITLE
feat : Optional SSL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,8 @@ SECRET_KEY='your_very_secret_flask_key'
 # Mettre à 1 pour activer le mode débogage de Flask (rechargement automatique, logs détaillés).
 # Mettre à 0 pour le mode production.
 FLASK_DEBUG=1
+
+# --- HTTPS ---
+# Mettre à "true" pour utiliser HTTPS (par défaut).
+# Mettre à "false" pour utiliser HTTP (non sécurisé).
+USE_SSL=true

--- a/src/app.py
+++ b/src/app.py
@@ -157,4 +157,8 @@ if __name__ == '__main__':
     init_db()
     # Le mode debug est contrôlé par la variable d'environnement FLASK_DEBUG
     is_debug_mode = os.getenv('FLASK_DEBUG') == '1'
-    app.run(host='0.0.0.0', port=5001, debug=is_debug_mode, ssl_context='adhoc')
+    use_ssl = os.environ.get("USE_SSL", "true").lower() != "false"
+    if use_ssl:
+        app.run(host='0.0.0.0', port=5001, ssl_context='adhoc')
+    else:
+        app.run(host='0.0.0.0', port=5001)


### PR DESCRIPTION
Bonjour,

Un petit ajout, pour donner la possibilité de désactiver le SSL.
C'est utile dans certains cas notament derrière un reverse proxy.

Il suffit de déclarer la variable `USE_SSL` qui sera `true` ou `false` *(par défaut, implicitement vraie)*.

**NB** : C'est complètement optionnel, si la variable n'est pas déclarée on en reste au fonctionnement actuel.
